### PR TITLE
Implement preserve route redirect on login and only refresh on 401s

### DIFF
--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -65,7 +65,7 @@ class ApiClient {
   }
 
   private shouldAttemptRefresh(response: AxiosResponse): boolean {
-    return [401, 403].includes(response.status) && !response.config.url?.includes('/auth/refresh');
+    return response.status === 401 && !response.config.url?.includes('/auth/refresh');
   }
 }
 

--- a/ui/src/components/auth/LoginPage.tsx
+++ b/ui/src/components/auth/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { Button, Container, Form, FormField, Header, Input, SpaceBetween } from '@cloudscape-design/components';
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/auth/authContext';
 import { FullPageCenteredBoxLayout } from '../../layouts/FullPageCentredBoxLayout';
 import { LoadingLayout } from '../../layouts/LoadingLayout';
@@ -9,6 +9,9 @@ import { ErrorBox } from '../global/ErrorBox';
 
 const LoginPage = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const from = location.state?.from?.pathname || '/';
 
   const [error, setError] = useState<Error>();
   const [loading, setLoading] = useState(false);
@@ -28,7 +31,7 @@ const LoginPage = () => {
 
       await login({ email, password });
 
-      navigate('/');
+      navigate(from, { replace: true });
     } catch (err) {
       setError(err as Error);
     } finally {

--- a/ui/src/routing/PrivateRoutes.tsx
+++ b/ui/src/routing/PrivateRoutes.tsx
@@ -1,10 +1,11 @@
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/auth/authContext';
 
 export default function PrivateRoutes() {
   const { isLoggedIn, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) return;
 
-  return isLoggedIn() ? <Outlet /> : <Navigate to="/landing" />;
+  return isLoggedIn() ? <Outlet /> : <Navigate to="/landing" state={{ from: location }} replace />;
 }


### PR DESCRIPTION
- Preserve route redirect when logging in
- Only attempt token refresh on 401 response
  - Due to RBAC returning 403